### PR TITLE
fix(engineio): respect pingTimeout and pingInterval to stop connection

### DIFF
--- a/engineio/src/asynchronous/client/async_client.rs
+++ b/engineio/src/asynchronous/client/async_client.rs
@@ -54,7 +54,8 @@ impl Client {
         socket: InnerSocket,
     ) -> Pin<Box<impl Stream<Item = Result<Packet>> + 'static + Send>> {
         Box::pin(try_stream! {
-            for await item in socket.clone() {
+            let socket = socket.clone();
+            for await item in socket.as_stream() {
                 let packet = item?;
                 socket.handle_incoming_packet(packet.clone()).await?;
                 yield packet;

--- a/engineio/src/client/client.rs
+++ b/engineio/src/client/client.rs
@@ -1,5 +1,6 @@
 use super::super::socket::Socket as InnerSocket;
 use crate::callback::OptionalCallback;
+use crate::socket::DEFAULT_MAX_POLL_TIMEOUT;
 use crate::transport::Transport;
 
 use crate::error::{Error, Result};
@@ -128,7 +129,8 @@ impl ClientBuilder {
 
         let mut url = self.url.clone();
 
-        let handshake: HandshakePacket = Packet::try_from(transport.poll()?)?.try_into()?;
+        let handshake: HandshakePacket =
+            Packet::try_from(transport.poll(DEFAULT_MAX_POLL_TIMEOUT)?)?.try_into()?;
 
         // update the base_url with the new sid
         url.query_pairs_mut().append_pair("sid", &handshake.sid[..]);

--- a/engineio/src/error.rs
+++ b/engineio/src/error.rs
@@ -52,6 +52,8 @@ pub enum Error {
     InvalidHeaderNameFromReqwest(#[from] reqwest::header::InvalidHeaderName),
     #[error("Invalid header value")]
     InvalidHeaderValueFromReqwest(#[from] reqwest::header::InvalidHeaderValue),
+    #[error("The server did not send a PING packet in time")]
+    PingTimeout(),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/engineio/src/transport.rs
+++ b/engineio/src/transport.rs
@@ -2,7 +2,7 @@ use super::transports::{PollingTransport, WebsocketSecureTransport, WebsocketTra
 use crate::error::Result;
 use adler32::adler32;
 use bytes::Bytes;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use url::Url;
 
 pub trait Transport {
@@ -13,7 +13,7 @@ pub trait Transport {
     /// Performs the server long polling procedure as long as the client is
     /// connected. This should run separately at all time to ensure proper
     /// response handling from the server.
-    fn poll(&self) -> Result<Bytes>;
+    fn poll(&self, timeout: Duration) -> Result<Bytes>;
 
     /// Returns start of the url. ex. http://localhost:2998/engine.io/?EIO=4&transport=polling
     /// Must have EIO and transport already set.

--- a/engineio/src/transports/polling.rs
+++ b/engineio/src/transports/polling.rs
@@ -8,6 +8,7 @@ use reqwest::{
     header::HeaderMap,
 };
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use url::Url;
 
 #[derive(Debug, Clone)]
@@ -77,8 +78,13 @@ impl Transport for PollingTransport {
         Ok(())
     }
 
-    fn poll(&self) -> Result<Bytes> {
-        Ok(self.client.get(self.address()?).send()?.bytes()?)
+    fn poll(&self, timeout: Duration) -> Result<Bytes> {
+        Ok(self
+            .client
+            .get(self.address()?)
+            .timeout(timeout)
+            .send()?
+            .bytes()?)
     }
 
     fn base_url(&self) -> Result<Url> {


### PR DESCRIPTION
The Engine.IO protocol features a heartbeat mechanism which ensures that the connection between server and client is alive. During that heartbeat, the server sends PINGs to which the client responds with PONGs. Both parties can therefore detect whether the connection is still alive, based on the pingInterval and pingTimeout received in the initial handshake.

However, we previously didn't make use of that in the Engine.IO implementation, which lead to disconnects not being properly recognized.

We now respect these settings and return an error and disconnect the connection, once the pingInterval+pingTimeout time has passed.

See also https://socket.io/docs/v4/how-it-works/#disconnection-detection